### PR TITLE
Route protection

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server"
+
+import { auth } from "@/auth"
+
+
+export default async function (request: any) {
+    // routes protection works as expected when the user is unauthenticated. However, if the user logs in this specific statement `const session = await auth(request)` throws the following error:
+    // **PrismaClient is not configured to run in Vercel Edge Functions or Edge Middleware**
+
+    // this workaround fixes the above as 'authjs.session-token' only exists when the user is authenticated
+    // Note that as far as I know, nextjs handles cookies as HTTP-only
+    const cookieData: Map<string, any> = request.cookies._parsed
+    if (!cookieData.get('authjs.session-token')) {
+        const session = await auth(request)
+        if (!session?.user) {
+            return NextResponse.redirect(new URL('/', request.url))
+        }
+    }
+}
+
+// protect all routes except the ones that match this pattern
+export const config = { matcher: ['/((?!$|api|_next/static|_next/image|favicon.ico).*)'] }


### PR DESCRIPTION
### Related to: #11

#### Changes:
- Add middleware for route protection.

Please note that I've added a workaround to make this work with Prisma. Without the workaround, route protection works as expected when the user is unauthenticated. However, if the user is logged in, nextjs throws the following error:

> **PrismaClient is not configured to run in Vercel Edge Functions or Edge Middleware**

I tried other approaches such as Prisma Accelerate and adapters, but they did not work

---
##### Closes #11